### PR TITLE
replace types verification by isinstance(x, type).

### DIFF
--- a/sinkhorn_knopp/sinkhorn_knopp.py
+++ b/sinkhorn_knopp/sinkhorn_knopp.py
@@ -1,5 +1,4 @@
 import warnings
-from types import IntType, FloatType
 
 import numpy as np
 
@@ -71,15 +70,13 @@ class SinkhornKnopp:
     """
 
     def __init__(self, max_iter=1000, epsilon=1e-3):
-        assert type(max_iter) is IntType or\
-            type(max_iter) is FloatType,\
+        assert isinstance(max_iter, int) or isinstance(max_iter, float),\
             "max_iter is not of type int or float: %r" % max_iter
         assert max_iter > 0,\
             "max_iter must be greater than 0: %r" % max_iter
         self._max_iter = int(max_iter)
 
-        assert type(epsilon) is FloatType or\
-            type(epsilon) is IntType,\
+        assert isinstance(epsilon, int) or isinstance(epsilon, float),\
             "epsilon is not of type float or int: %r" % epsilon
         assert epsilon > 0 and epsilon < 1,\
             "epsilon must be between 0 and 1 exclusive: %r" % epsilon


### PR DESCRIPTION
In order to be able to run it on python 3.6 (so probably also previous versions), I replaced checks done using "types" library by a check by isinstance(X, int/float). I've done some trials and checks are still done properly. 